### PR TITLE
하스켈 GHCi 설정 파일 .gitignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -504,3 +504,6 @@ fabric.properties
 !/gradle/wrapper/gradle-wrapper.jar
 
 # End of https://www.toptal.com/developers/gitignore/api/python,kotlin,swift,erlang,dart,elixir,visualstudiocode,androidstudio,xcode
+
+# Haskell GHCi config file
+.ghci


### PR DESCRIPTION
하스켈 ghci 혹은 ghcid 사용할 때 쓰는 설정 파일입니다.

트래킹이 안되도록 제외 리스트에 추가했습니다!