### PR TITLE
CODEOWNERS 추가

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+**/*.* @plain-bagel/aoc


### PR DESCRIPTION
PR Reviewer에 자동으로 @plain-bagel/aoc 가 포함되도록 설정합니다! :octocat: 

파일 확장자, 위치 별로도 추가가 가능하니, 혹시 필요하다면 이후에 추가해도 좋겠습니다.