### PR TITLE
Day 7: Camel Cards 문제 풀이 - @renardyreveur

### DIFF
--- a/07/renardyreveur/BaseParser.hs
+++ b/07/renardyreveur/BaseParser.hs
@@ -1,0 +1,102 @@
+module BaseParser (
+    Parser (..),
+    charP,
+    stringP,
+    spanP,
+    notNull,
+    intP,
+    sepBy,
+    ws,
+    fromMaybe,
+    sHead,
+    sTail,
+    stringLiteralP,
+    spaceP,
+) where
+
+import Control.Applicative
+import Data.Char (isDigit, isSpace)
+
+-- Define Parser type for generic type a
+newtype Parser a = Parser
+    { runParser :: String -> Maybe (a, String)
+    }
+
+instance Functor Parser where
+    fmap f (Parser p) = Parser $ \input ->
+        case p input of
+            Just (y, ys) -> Just (f y, ys)
+            Nothing -> Nothing
+
+instance Applicative Parser where
+    pure p = Parser $ \input -> Just (p, input)
+    (Parser p1) <*> (Parser p2) = Parser $ \input ->
+        case p1 input of
+            Just (f, rest) ->
+                case p2 rest of
+                    Just (x, leftover) -> Just (f x, leftover)
+                    Nothing -> Nothing
+            Nothing -> Nothing
+
+instance Alternative Parser where
+    empty = Parser $ \_ -> Nothing -- always fail
+    (Parser p1) <|> (Parser p2) = Parser $ \input ->
+        case p1 input of
+            Just (x, leftover) -> Just (x, leftover)
+            Nothing -> p2 input
+
+charP :: Char -> Parser Char
+charP x = Parser f
+  where
+    f (y : ys)
+        | y == x = Just (x, ys)
+        | otherwise = Nothing
+    f [] = Nothing
+
+stringP :: String -> Parser String
+stringP [] = pure []
+stringP (c : cs) = (:) <$> charP c <*> stringP cs -- Recursive chaining of charP
+
+-- Parse based on predicate condition
+spanP :: (Char -> Bool) -> Parser String
+spanP f = Parser $ \input -> Just (span f input)
+
+-- Parser that returns Nothing if the result is empty
+notNull :: Parser [a] -> Parser [a]
+notNull (Parser p) = Parser $ \input ->
+    case p input of
+        Just ([], _) -> Nothing
+        Just (x, xs) -> Just (x, xs)
+        Nothing -> Nothing
+
+-- Parser for integer
+intP :: Parser Int
+intP = read <$> notNull (spanP isDigit)
+
+-- Parser for general String
+stringLiteralP :: Parser String
+stringLiteralP = spanP (\x -> not $ x `elem` ['"', ' '])
+
+-- First create a parser that parses an element with a separator, and returns a list of elements separated by the separator
+sepBy :: Parser a -> Parser b -> Parser [b]
+sepBy sep element = (:) <$> element <*> many (sep *> element) <|> pure [] -- Inject (:) into the functor, then apply to element, then apply to many (sep *> element)
+
+-- Handle whitespace around delimiters
+ws :: Parser String
+ws = spanP isSpace
+
+-- Handle whitespace around delimiters
+spaceP :: Parser String
+spaceP = spanP (\x -> x == ' ')
+
+fromMaybe :: Maybe a -> a
+fromMaybe (Just x) = x
+fromMaybe Nothing = error "Nothing"
+
+sHead :: [a] -> a
+sHead [] = error "Empty list"
+sHead (x : _) = x
+
+sTail :: [a] -> [a]
+sTail [] = error "Empty list"
+sTail (_ : xs) = xs

--- a/07/renardyreveur/Main.hs
+++ b/07/renardyreveur/Main.hs
@@ -1,0 +1,112 @@
+module Main where
+
+import BaseParser
+import Data.List (nub, sort)
+
+-- Create Data Structure
+data HandType = HighCard | OnePair | TwoPair | ThreeofAKind | FullHouse | FourofAKind | FiveofAKind deriving (Show, Eq, Ord)
+
+-- data CardType = N | T | J | Q | K | A deriving (Show, Eq, Ord) --- Part 1
+data CardType = J | N | T | Q | K | A deriving (Show, Eq, Ord) -- Part 2
+
+data Hand = Hand
+    { cards :: String
+    , cardtype :: [CardType]
+    , bid :: Int
+    , handtype :: HandType
+    }
+    deriving (Show)
+instance Eq Hand where
+    (==) (Hand s1 _ _ _) (Hand s2 _ _ _) = s1 == s2
+instance Ord Hand where
+    compare h1 h2 = compareHand h1 h2
+
+-- Classify Hands into type
+classifyHand :: String -> HandType
+classifyHand h =
+    case nub h of
+        [c] -> FiveofAKind
+        [c1, c2] -> if any (\ct -> (length (filter (== ct) h)) == 4) [c1, c2] then FourofAKind else FullHouse
+        [c1, c2, c3] -> if any (\ct -> (length (filter (== ct) h)) == 3) [c1, c2, c3] then ThreeofAKind else TwoPair
+        [c1, c2, c3, c4] -> if any (\ct -> (length (filter (== ct) h)) == 2) [c1, c2, c3, c4] then OnePair else HighCard
+        _ -> HighCard
+
+-- Classify Cards into type
+classifyCard :: Char -> CardType
+classifyCard c =
+    case c of
+        'T' -> T
+        'J' -> J
+        'Q' -> Q
+        'K' -> K
+        'A' -> A
+        _ -> N
+
+-- Compare single card
+compareCard :: (CardType, Char) -> (CardType, Char) -> Ordering
+compareCard (c1, s1) (c2, s2)
+    | c1 > c2 = GT
+    | c1 < c2 = LT
+    | otherwise =
+        -- 2 cases: either both are N or both are same non-N card type
+        case (c1, c2) of
+            (N, N) -> compare s1 s2
+            _ -> EQ
+
+-- Compare hands
+compareHand :: Hand -> Hand -> Ordering
+compareHand (Hand [] [] b1 h1) (Hand [] [] b2 h2) = EQ
+compareHand (Hand (s1 : ss1) (c1 : cc1) b1 h1) (Hand (s2 : ss2) (c2 : cc2) b2 h2)
+    | (h1 > h2) = GT
+    | (h1 < h2) = LT
+    | otherwise =
+        case compareCard (c1, s1) (c2, s2) of
+            GT -> GT
+            EQ -> compareHand (Hand ss1 cc1 b1 h1) (Hand ss2 cc2 b2 h2)
+            LT -> LT
+
+-- Parsers
+parseHand :: Parser (String, Int)
+parseHand = (,) <$> stringLiteralP <* ws <*> intP
+
+-- Main
+main :: IO ()
+main = do
+    -- Read Input file
+    hands <- readFile "07/input.txt"
+
+    -- Card hands
+    let cardHands = map (fst . fromMaybe . runParser parseHand) (lines hands)
+
+    -- Classify hands
+    let classifiedHands = map (\(h, b) -> Hand h (map classifyCard h) b (classifyHand h)) cardHands
+
+    -- Sort hands from weakest to strongest
+    let sortedHands = sort classifiedHands
+
+    -- Total Winning Bid
+    let totalBid = sum $ [rank * b | (rank, b) <- zip [1 .. length cardHands] (map bid sortedHands)]
+
+    -- Print total winning bid
+    putStrLn $ "Total Winning Bid: " ++ show totalBid
+
+    -- Part2
+    let subs = "23456789TQKA"
+
+    -- First Try: I tried promoting HandTypes by the number of J's in the hand, realized it wouldn't work as there isn't a single promotion order
+    -- As soon as there are more than three (JJJ), promotion order is not clear
+
+    -- Try replacing 'J' with each character in subs, get best hand type (thankful for the Ord instance of HandType > <)
+    let cardHands2 = map (\(h, _) -> maximum [classifyHand $ map (\c -> if c == 'J' then s else c) h | s <- subs]) cardHands
+
+    -- Newly classified hands
+    let classifiedHands2 = map (\((s, b), h) -> Hand s (map classifyCard s) b h) $ zip cardHands cardHands2
+
+    -- Sort hands from weakest to strongest
+    let sortedHands2 = sort classifiedHands2
+
+    -- Total Winning Bid
+    let totalBid2 = sum $ [rank * b | (rank, b) <- zip [1 .. length cardHands] (map bid sortedHands2)]
+
+    -- Print total winning bid
+    putStrLn $ "Total Winning Bid with Joker J: " ++ show totalBid2


### PR DESCRIPTION
## ✔️ Solution

- 카드 Hand와 각각의 카드에 대한 간단한 타입을 만들고, 각 타입마다 `Ord` 인스턴스를 만들어서 순서를 비교할 수 있게 만들었습니다. ☄️ 
- 주어진 Hand 의 unique한 카드의 갯수를 가지고 무슨 패인지 구분하는 함수를 만들었습니다. 🎴 

//

- Part 2는 무언가 J가 존재 할때 마다 기존 패를 promote 하는 방식으로 풀어보려고 했으나, J의 갯수가 3개 이상이 될때 문제가 되는 것을 발견하고는 다르게 접근했습니다. 🙏 
- 각 J의 위치에 "234..QKA"를 다 한번씩 대입해보고 만들어지는 최고의 패를 가리게 했습니다 (Hand에 대한 Ord를 만들었음으로 maximum 함수를 바로 사용 가능) 

 
## ✔️ Learned

- 하스켈에서 새로운 데이터 타입을 만들때, Ord 타입 클래스를 상속 받는다고 하면 자동으로 Data constructor들이 기입된 순서로 ordering을 만들어 준다는 것을 배웠습니다! 추가적인 `instance Ord X  where ... ` 를 작성하지 않아도 된다는 점이 맘에 들었습니다 ㅎㅎ 😆 

- @eunice-hong 과 @sunghwajun 과 문제 풀이 공유를 하면서 @sunghwajun 의 promote 비슷한 느낌의 파트 2 풀이와, 스트링 소팅의 기본 순서를 활용한 꿀팁에 또 한번 배워갑니다!! 🎉 
